### PR TITLE
Register serializers with IknowParams::Parser 

### DIFF
--- a/lib/iknow_params/parser.rb
+++ b/lib/iknow_params/parser.rb
@@ -4,8 +4,6 @@ require "active_support/concern"
 require "active_support/inflector"
 require "active_support/core_ext/object/blank"
 
-require "iknow_params/serializer"
-
 # IknowParams::Parser provides a mix-in for ActiveRecord controllers to parse input parameters.
 module IknowParams::Parser
   require "iknow_params/parser/hash_parser"
@@ -144,11 +142,16 @@ module IknowParams::Parser
     end
   end
 
-  # Add default parse methods for each basic serializer class
-  ObjectSpace.each_object(IknowParams::Serializer.singleton_class).each do |serializer_class|
-    name = serializer_class.name.demodulize.underscore
-    define_method(:"parse_#{name}_param") do |param, default: PARAM_REQUIRED|
-      parse_param(param, with: serializer_class, default: default)
+  # Allow serializers to register themselves
+  def self.register_serializer(name, serializer)
+    define_method(:"parse_#{name.underscore}_param") do |param, default: PARAM_REQUIRED|
+      parse_param(param, with: serializer, default: default)
     end
+    define_method(:"parse_#{name.underscore}_array_param") do |param, default: PARAM_REQUIRED|
+      parse_array_param(param, with: serializer, default: default)
+    end
+
   end
 end
+
+require 'iknow_params/serializer'

--- a/lib/iknow_params/serializer.rb
+++ b/lib/iknow_params/serializer.rb
@@ -9,6 +9,7 @@ require 'json-schema'
 
 module IknowParams
 class Serializer
+  require 'iknow_params/parser'
   class LoadError < ArgumentError; end
   class DumpError < ArgumentError; end
 
@@ -68,6 +69,7 @@ class Serializer
 
     def register_serializer(name, serializer)
       @registry[name] = serializer
+      IknowParams::Parser.register_serializer(name, serializer)
     end
 
     private

--- a/lib/iknow_params/version.rb
+++ b/lib/iknow_params/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowParams
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end

--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -82,6 +82,12 @@ RSpec.describe IknowParams::Parser do
         expect(parsed).to eq 5
       end
 
+      it "registers a typed parse method" do
+        params = { id: "5" }
+        param  = :id
+        expect(Controller.new(params).parse_integer_param(param)).to eq 5
+      end
+
       it "requires the value" do
         @params = {name: "5"}
         @param  = :id
@@ -124,6 +130,18 @@ RSpec.describe IknowParams::Parser do
 
           expect(parsed).to eq "10"
         end
+      end
+    end
+
+    context "with a complex named serializer" do
+      class ThisInterestingType < IknowParams::Serializer::Integer
+        set_singleton!
+      end
+
+      it "registers a typed parse method" do
+        params = { id: "5" }
+        param  = :id
+        expect(Controller.new(params).parse_this_interesting_type_param(param)).to eq 5
       end
     end
   end
@@ -187,6 +205,12 @@ RSpec.describe IknowParams::Parser do
         @param  = :ids
 
         expect(parsed).to eq [4, 5]
+      end
+
+      it "registers a typed parse array method" do
+        params = { ids: ['4', '5'] }
+        param  = :ids
+        expect(Controller.new(params).parse_integer_array_param(param)).to eq [4, 5]
       end
 
       it "requires the value" do


### PR DESCRIPTION
to generate parse_x_param methods, rather than using ObjectSpace to find known serializers at load time.