### PR TITLE
Update json-schema dependency and Ruby version requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
         type: string
         default: "Gemfile"
     docker:
-      - image: circleci/ruby:<< parameters.ruby-version >>
+      - image: cimg/ruby:<< parameters.ruby-version >>
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -92,9 +92,13 @@ workflows:
           ruby-version: "2.6"
           gemfile: gemfiles/activesupport_5_2.gemfile
       - test:
-          name: 'ruby 2.6 ActiveSupport 6.0'
-          ruby-version: "2.6"
+          name: 'ruby 2.7 ActiveSupport 6.0'
+          ruby-version: "2.7"
           gemfile: gemfiles/activesupport_6_0.gemfile
+      - test:
+          name: 'ruby 3.1 ActiveSupport 7.0'
+          ruby-version: "3.1"
+          gemfile: gemfiles/activesupport_7_0.gemfile
       - publish:
           filters:
             branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: trusty
-language: ruby
-rvm:
-  - 2.4
-gemfile:
-  - gemfiles/activesupport_5_2.gemfile
-notifications:
-  email: false

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,14 @@
-appraise "activesupport-5-2" do
-  gem "activesupport", "~> 5.2.0"
+appraise 'activesupport-5-2' do
+  gem 'activesupport', '~> 5.2.0'
+  gem 'rails', '~> 5.2.0'
 end
 
-appraise 'activesupport-6-0 do
-  gem 'activesupport', '~> 6.0.0"
+appraise 'activesupport-6-0' do
+  gem 'activesupport', '~> 6.0.0'
+  gem 'rails', '~> 6.0.0'
+end
+
+appraise 'activesupport-7-0' do
+  gem 'activesupport', '~> 7.0.0'
+  gem 'rails', '~> 7.0.0'
 end

--- a/gemfiles/activesupport_5_2.gemfile
+++ b/gemfiles/activesupport_5_2.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "rspec_junit_formatter"
 gem "activesupport", "~> 5.2.0"
+gem "rails", "~> 5.2.0"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_7_0.gemfile
+++ b/gemfiles/activesupport_7_0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rspec_junit_formatter"
-gem "activesupport", "~> 6.0.0"
-gem "rails", "~> 6.0.0"
+gem "activesupport", "~> 7.0.0"
+gem "rails", "~> 7.0.0"
 
 gemspec path: "../"

--- a/iknow_params.gemspec
+++ b/iknow_params.gemspec
@@ -13,23 +13,26 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/iknow/iknow_params"
   spec.license       = "MIT"
 
+  spec.required_ruby_version     = ">= 2.5"
+  spec.required_rubygems_version = ">= 2.5"
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "actionpack", "> 5.0"
-  spec.add_development_dependency "rails", "> 5.0"
+  spec.add_development_dependency "actionpack", "> 5.2.0"
+  spec.add_development_dependency "rails", "> 5.2.0"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "tzinfo-data"
 
-  spec.add_dependency "activesupport", "> 5.0"
+  spec.add_dependency "activesupport", "> 5.2.0"
   spec.add_dependency "tzinfo"
-  spec.add_dependency "json-schema", "~> 2.8.0"
+  spec.add_dependency "json-schema", "~> 3.0.0"
 end

--- a/lib/iknow_params/serializer.rb
+++ b/lib/iknow_params/serializer.rb
@@ -177,6 +177,8 @@ class IknowParams::Serializer
   # Abstract serializer for ISO8601 dates and times
   class ISO8601 < IknowParams::Serializer
     def load(str)
+      raise TypeError.new unless str.is_a?(::String)
+
       clazz.parse(str)
     rescue TypeError, ArgumentError => _e
       raise LoadError.new("Invalid type for conversion to #{clazz}")

--- a/lib/iknow_params/version.rb
+++ b/lib/iknow_params/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowParams
-  VERSION = '2.2.4'
+  VERSION = '2.3.0'
 end

--- a/spec/unit/serializer_spec.rb
+++ b/spec/unit/serializer_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'iknow_params'
 
 require 'rails'
+require 'active_support/core_ext'
 require 'action_controller'
 
 RSpec.describe IknowParams::Serializer do


### PR DESCRIPTION
json-schema 3.0.0 requires Ruby 2.5.